### PR TITLE
Update build instructions

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -11,9 +11,12 @@ Make sure `libpq5` and `libpq-dev` are installed, and `python` refers Python2.
 git clone https://github.com/deepkit/deepkit-framework.git
 cd deepkit-framework
 npm install
+npm run bootstrap # this is expected to fail
+npx tsc --build packages/type-compiler/tsconfig.json
 npm run bootstrap
 npm run link
 npm run install-compiler
+npm run build
 ```
 
 ## Making changes


### PR DESCRIPTION
Build as described would fail on a clean checkout

Running bootstrap requires that the type-compiler already be
transpiled, but the transpilation depends on files produced by
bootstrap.

Break the cycle by running splitting bootstrap in two.

While at it, also run "npm run build".

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
