### PR TITLE
Respect reflectionMode in findReflectionFromPath

### DIFF
--- a/packages/type-compiler/src/compiler.ts
+++ b/packages/type-compiler/src/compiler.ts
@@ -2380,6 +2380,7 @@ export class ReflectionTransformer implements CustomTransformer {
         if (!serverEnv) {
             return { mode: 'default' };
         }
+        if (this.reflectionMode !== undefined) return { mode: this.reflectionMode };
 
         let currentDir = dirname(path);
         let reflection: typeof reflectionModes[number] | undefined;


### PR DESCRIPTION
This is needed when trying to integrate the type compiler with deno,
as there will be no tsconfig and the caller has to explicitly say if
reflection is wanted.

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
