### PR TITLE
fix(orm): do not skip all other uow listeners if one event has default prevented

### DIFF
--- a/packages/orm/src/database-session.ts
+++ b/packages/orm/src/database-session.ts
@@ -169,7 +169,7 @@ export class DatabaseSessionRound<ADAPTER extends DatabaseAdapter> {
             if (this.eventDispatcher.hasListeners(DatabaseSession.onDeletePre)) {
                 const event = new UnitOfWorkEvent(classSchema, this.session, items);
                 await this.eventDispatcher.dispatch(DatabaseSession.onDeletePre, event);
-                if (event.defaultPrevented) return;
+                if (event.defaultPrevented) continue;
             }
 
             await persistence.remove(classSchema, items);


### PR DESCRIPTION
### Summary of changes

Currently the uow events are skipped if one event has its default prevented. We want to continue the loop instead to also dispatch events for possible other class schemas.

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
