### PR TITLE
fix(orm): return soft delete query results to be consistent with normal query operation results

### DIFF
--- a/packages/orm/src/plugin/soft-delete-plugin.ts
+++ b/packages/orm/src/plugin/soft-delete-plugin.ts
@@ -98,21 +98,21 @@ export class SoftDeleteQuery<T extends SoftDeleteEntity> extends Query<T> {
     async restoreOne() {
         const patch = { [deletedAtName]: undefined } as Partial<T>;
         if (this.classSchema.hasProperty('deletedBy')) patch['deletedBy'] = undefined;
-        await this.withSoftDeleted().patchOne(patch);
+        return this.withSoftDeleted().patchOne(patch);
     }
 
     async restoreMany() {
         const patch = { [deletedAtName]: undefined } as Partial<T>;
         if (this.classSchema.hasProperty('deletedBy')) patch['deletedBy'] = undefined;
-        await this.withSoftDeleted().patchMany(patch);
+        return this.withSoftDeleted().patchMany(patch);
     }
 
     async hardDeleteOne() {
-        await this.withSoftDeleted().deleteOne();
+        return this.withSoftDeleted().deleteOne();
     }
 
     async hardDeleteMany() {
-        await this.withSoftDeleted().deleteMany();
+        return this.withSoftDeleted().deleteMany();
     }
 }
 


### PR DESCRIPTION
### Summary of changes

the functions of the soft-delete plugin `restoreOne()`, `restoreMany()`, `hardDeleteOne()` & `hardDeleteMany()` are using the query functions `patchOne()`, `patchMany()`, `deleteOne()` & `deleteMany()` under the hood. We should probably return the result of those operations as well so they are consistent and can be used identically to the underlying query functions.


### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
