### PR TITLE
fix(type): fix type collapse when B resolves to unknown

### DIFF
--- a/packages/type/src/reflection/processor.ts
+++ b/packages/type/src/reflection/processor.ts
@@ -1450,6 +1450,8 @@ export class Processor {
                 return { kind: ReflectionKind.never };
             }
 
+            if (b.kind === ReflectionKind.unknown) return a;
+
             if (a.kind === ReflectionKind.objectLiteral || a.kind === ReflectionKind.class || a.kind === ReflectionKind.never || a.kind === ReflectionKind.unknown) return b;
 
             if (b.annotations) {

--- a/packages/type/tests/type.spec.ts
+++ b/packages/type/tests/type.spec.ts
@@ -133,6 +133,31 @@ test('intersection with never', () => {
     expect(groupAnnotation.getAnnotations(typeOf<C>())).toEqual(['c']);
 });
 
+test('intersection with unknown', () => {
+    // T & unknown = T (unknown is absorbed in intersections, per TypeScript semantics)
+    expect(stringifyType(typeOf<string & unknown>())).toBe('string');
+    expect(stringifyType(typeOf<unknown & string>())).toBe('string');
+    expect(stringifyType(typeOf<number & unknown>())).toBe('number');
+    expect(stringifyType(typeOf<unknown & number>())).toBe('number');
+    expect(stringifyType(typeOf<boolean & unknown>())).toBe('boolean');
+    expect(stringifyType(typeOf<bigint & unknown>())).toBe('bigint');
+    expect(stringifyType(typeOf<null & unknown>())).toBe('null');
+    expect(stringifyType(typeOf<undefined & unknown>())).toBe('undefined');
+
+    // object literal & unknown = object literal
+    type MyObj = { a: string };
+    expect(stringifyType(typeOf<MyObj & unknown>())).toBe('MyObj');
+    expect(stringifyType(typeOf<unknown & MyObj>())).toBe('MyObj');
+
+    // class & unknown = class
+    class MyClass { name!: string; }
+    expect(stringifyType(typeOf<MyClass & unknown>())).toBe('MyClass');
+    expect(stringifyType(typeOf<unknown & MyClass>())).toBe('MyClass');
+
+    // unknown & unknown = unknown
+    expect(stringifyType(typeOf<unknown & unknown>())).toBe('unknown');
+});
+
 test('intersection same type keep annotation', () => {
     type MyAnnotation = { __meta?: never & ['myAnnotation'] };
     type Username = string & MyAnnotation;


### PR DESCRIPTION
### Summary of changes

Fixes `type TestType = Object & unknown` to resolve to `Object` to align with how TypeScript handles "unknown" unions.

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [X] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
