### PR TITLE
fix(sql): use dynamic import instead of require to fix command execution in esm environments

### DIFF
--- a/packages/sql/src/cli/migration-create-command.ts
+++ b/packages/sql/src/cli/migration-create-command.ts
@@ -105,7 +105,7 @@ export class MigrationCreateController extends BaseCommand implements Command {
             let migrationName = '';
             const date = new Date;
 
-            const { format } = require('date-fns');
+            const { format } = await import('date-fns');
             for (let i = 1; i < 100; i++) {
                 migrationName = format(date, 'yyyyMMdd-HHmm');
                 if (i > 1) migrationName += '_' + i;


### PR DESCRIPTION
### Summary of changes
Replace require with dynamic import to make it possible to create migrations in ESM projects.
Without this fix executing the migration:up CLI command will fail in ESM projects with the following error:
```
The command "migration:create" failed.
ReferenceError: require is not defined
    at MigrationCreateController.execute (file:///home/[redacted]/[redacted]/[redacted]/node_modules/.pnpm/@deepkit+sql@1.0.19_31dfc4400a8ec8e24849ce756645ed23/node_modules/@deepkit/sql/dist/esm/src/cli/migration-create-command.js:105:32)
    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
    at async runCommand (file:///home/[redacted]/[redacted]/[redacted]/node_modules/.pnpm/@deepkit+app@1.0.19_20843fe189e7fb277e8cf388d1d7bb0b/node_modules/@deepkit/app/dist/esm/src/command.js:611:28)
    at async executeCommand (file:///home/[redacted]/[redacted]/[redacted]/node_modules/.pnpm/@deepkit+app@1.0.19_20843fe189e7fb277e8cf388d1d7bb0b/node_modules/@deepkit/app/dist/esm/src/command.js:363:16)
    at async App.execute (file:///home/[redacted]/[redacted]/[redacted]/node_modules/.pnpm/@deepkit+app@1.0.19_20843fe189e7fb277e8cf388d1d7bb0b/node_modules/@deepkit/app/dist/esm/src/app.js:314:20)
    at async App.run (file:///home/[redacted]/[redacted]/[redacted]/node_modules/.pnpm/@deepkit+app@1.0.19_20843fe189e7fb277e8cf388d1d7bb0b/node_modules/@deepkit/app/dist/esm/src/app.js:270:26)
```


### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
