### PR TITLE
fix(type-compiler): correct plugin export paths

### DIFF
--- a/packages/type-compiler/package.json
+++ b/packages/type-compiler/package.json
@@ -13,9 +13,9 @@
       "default": "./dist/esm/index.js"
     },
     "./plugin": {
-      "types": "./dist/cjs/plugin.d.ts",
-      "require": "./dist/cjs/plugin.js",
-      "default": "./dist/esm/plugin.js"
+      "types": "./dist/cjs/src/plugin.d.ts",
+      "require": "./dist/cjs/src/plugin.js",
+      "default": "./dist/esm/src/plugin.js"
     }
   },
   "bin": {


### PR DESCRIPTION
## Summary

The published `@deepkit/type-compiler@1.0.19` package exposes `./plugin`, but the export map points at files that are not present in the tarball:

```json
"./plugin": {
  "types": "./dist/cjs/plugin.d.ts",
  "require": "./dist/cjs/plugin.js",
  "default": "./dist/esm/plugin.js"
}
```

The published package contains the plugin files under `dist/*/src/` instead:

```text
dist/cjs/src/plugin.js
dist/cjs/src/plugin.d.ts
dist/esm/src/plugin.js
dist/esm/src/plugin.d.ts
```

This PR updates only the `./plugin` export paths to match the files that are actually emitted.

## Reproduction

```sh
rm -rf /tmp/mojobeep-deepkit-type-repro
mkdir -p /tmp/mojobeep-deepkit-type-repro
cd /tmp/mojobeep-deepkit-type-repro
npm init -y >/dev/null
npm install @deepkit/type-compiler@1.0.19 >/dev/null
node --input-type=module -e "import('@deepkit/type-compiler/plugin').catch(error => { console.log(error.code, error.message); process.exit(1) })"
```

Observed output:

```text
ERR_MODULE_NOT_FOUND Cannot find module .../node_modules/@deepkit/type-compiler/dist/esm/plugin.js
```

## Validation

I validated the corrected export paths against a clean install of the published package by patching only the local package metadata:

```text
PATCHED_DEEPKIT_ESM_OK [ 'deepkitType' ] function
PATCHED_DEEPKIT_CJS_OK [ 'deepkitType' ] function
PATCHED_DEEPKIT_TYPES_OK
```

I also verified this repository change with:

```sh
node -e "const p=require('./packages/type-compiler/package.json'); console.log(JSON.stringify(p.exports['./plugin'], null, 2))"
git diff --check
```
