### PR TITLE
chore(type-compiler): add package link metadata

### DIFF
--- a/packages/type-compiler/package.json
+++ b/packages/type-compiler/package.json
@@ -31,6 +31,10 @@
     "install": "rm -rf node_modules/typescript && node ./deepkit-type-install.js || exit 0"
   },
   "repository": "https://github.com/deepkit/deepkit-framework",
+  "homepage": "https://github.com/deepkit/deepkit-framework/tree/master/packages/type-compiler#readme",
+  "bugs": {
+    "url": "https://github.com/deepkit/deepkit-framework/issues"
+  },
   "author": "Marc J. Schmidt <marc@marcjschmidt.de>",
   "license": "MIT",
   "peerDependencies": {


### PR DESCRIPTION
## Summary
- add npm homepage metadata for `@deepkit/type-compiler`
- add npm bugs URL metadata pointing to the project issue tracker

## Verification
- `node - <<'NODE' ...` metadata assertion for `name`, `homepage`, and `bugs.url`
- `npm pack --dry-run --ignore-scripts --json` in `packages/type-compiler`
- `git diff --check`